### PR TITLE
Create CNAME for linking datacarpentry.org to GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.datacarpentry.org


### PR DESCRIPTION
Part of addressing #21. This piece is needed regardless of how we handle the DNS changes.