### PR TITLE
Add metadata to blog posts

### DIFF
--- a/_posts/2014-11-04-first.md
+++ b/_posts/2014-11-04-first.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Blog"
 title: Data Carpentry Blog
 teaser: "Announcing a Data Carpentry Blog"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 Data Carpentry has now established a blog for announcements or posts on topics of interest for Data Carpentry enthusiasts. If you have a topic for a post or would like to guest post here, please let us know!

--- a/_posts/2014-11-05-announce.md
+++ b/_posts/2014-11-05-announce.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Lessons"
 title: Moore Foundation contribution to Data Carpentry
 header:
@@ -7,7 +7,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 We are excited to announce that [Data Carpentry](http://www.datacarpentry.org/) has received a contribution from the [Moore

--- a/_posts/2014-12-15-guiding-data-carpentry.md
+++ b/_posts/2014-12-15-guiding-data-carpentry.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Lessons"
 title: Guiding Data Carpentry
 teaser: "Guidelines and directions for Data Carpentry"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 ## Guiding Data Carpentry

--- a/_posts/2015-01-23-genomics-hackathon.md
+++ b/_posts/2015-01-23-genomics-hackathon.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Lessons"
 title: Data Carpentry Genomics and Asssessment Hackathon
 teaser: "Announcing a Data Carpentry Genomics and Assessment Hackathon"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 Through the support of [SESYNC](https://www.sesync.org), [BEACON](http://beacon-center.org) and

--- a/_posts/2015-07-01-elixir-nl.md
+++ b/_posts/2015-07-01-elixir-nl.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Workshops"
 title: Data Carpentry Goes to the Netherlands
 teaser: "ELIXIR sponsored Data Carpentry workshop"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 **Last week, between 22nd and 25th June, we ran a Data Carpentry hackathon and workshop at the University of Utrecht, Netherlands. Both events were a part of [ELIXIR](http://www.elixir-europe.org/) Pilot Project aiming to develop Data and Software Carpentry training across the ELIXIR Nodes. The project is coordinated by ELIXIR UK and a number of other Nodes are partnering up, including ELIXIR Netherlands, ELIXIR Finland and ELIXIR Switzerland.**

--- a/_posts/2015-07-20-workshop-fees.md
+++ b/_posts/2015-07-20-workshop-fees.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Administration"
 title: Data Carpentry Workshop Fees
 teaser: "Workshop fees to increase for workshops scheduled after September 1, 2015 to help
@@ -9,7 +9,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 After discussion with our Steering Committee and the Software Carpentry Foundation, 

--- a/_posts/2015-08-12-moore.md
+++ b/_posts/2015-08-12-moore.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Support"
 title: "Grant from the Moore Foundation"
 teaser: "We are very pleased to announce that we've received a grant from the Gordon and Betty Moore Foundation."
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 We are extremely pleased to announce that Data Carpentry has received $750,000 in funding from the [Gordon and Betty Moore Foundation](http://moore.org). 

--- a/_posts/2015-10-29-tdwg.md
+++ b/_posts/2015-10-29-tdwg.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: ""
 title: "Data Carpentry in Africa"
 teaser: "First Data Carpentry workshop in Africa at the TDWG conference"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 by Matt Collins at [iDigBio](https://www.idigbio.org)

--- a/_posts/2015-11-12-fasttrack.md
+++ b/_posts/2015-11-12-fasttrack.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Instructors"
 title: "Data Carpentry Instructor Certification <br>for Software Carpentry Instructors"
 teaser: "Already a Software Carpentry instructor? Become a Data Carpentry instructor too!"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 Data Carpentry has been growing over the last year, and now with the addition of Maneesha Sane as Program Coordinator, we have the chance to run even more workshops in more domains. To date, we have used some great instructors from the Software Carpentry community as teachers; what we would like to do now is put that on a more regular footing.

--- a/_posts/2015-11-19-ropensci.md
+++ b/_posts/2015-11-19-ropensci.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Support"
 title: "Collaboration with rOpenSci on training for working with open data"
 teaser: "A grant to rOpenSci from Helmsley Charitable Trust supports a collaboration with Data Carpentry to develop training for the use and publication of open data."
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 Congratulations to [rOpenSci](https://www.ropensci.org) for their [grant from the Helmsley Charitable Trust](https://www.ropensci.org/blog/2015/11/19/hemlsley-trust-funding)! Through this grant, Data Carpentry will be able to work with rOpenSci to develop and deliver lessons on R tools for data sharing, acquisition, retrieval, and visualization to support the use and publishing of open data.

--- a/_posts/2015-11-25-brussels-workshop.md
+++ b/_posts/2015-11-25-brussels-workshop.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: ""
 title: "Workshop in Brussels, 2-3 Nov 2015"
 teaser: "At the beginning of November, Belgium held its first Data Carpentry workshop."
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 Belgium has a flourishing biological research community and skills in data handling have become an essential tool for anyone conducting biodiversity science.

--- a/_posts/2015-11-30-associate-director-posting.md
+++ b/_posts/2015-11-30-associate-director-posting.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Staff"
 title: "Hiring an Associate Director"
 teaser: "We're hiring an Associate Director to lead community engagement and education efforts"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 

--- a/_posts/2015-12-16-reproducible-research-curriculum.md
+++ b/_posts/2015-12-16-reproducible-research-curriculum.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Curriculum"
 title: "Data Carpentry to adopt Reproducible Research Curriculum"
 teaser: "Curriculum added to Data Carpentry to further support training in reproducible research"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 **by Karen Cranston**

--- a/_posts/2016-01-25-workshops.md
+++ b/_posts/2016-01-25-workshops.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Workshops"
 title: "Starting off Data Carpentry in 2016"
 teaser: "Several workshops starting off Data Carpentry in 2016"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 In 2015 we were just starting out as an organization and ran limited workshops as we were working to scale. With many Software Carpentry instructors now certified as Data Carpentry instructors, our Program Coordinator, Maneesha Sane, coordinating workshops, a new website and an instructor database, in 2016 we're set to do a lot more!

--- a/_posts/2016-03-18-instructor-training-africa.md
+++ b/_posts/2016-03-18-instructor-training-africa.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Instructors"
 title: "Software and Data Carpentry Instructor Training Comes to Africa"
 teaser: "Instructor training event will take place in Potchefstroom, North-West Province, South Africa from 17 - 20 April 2016"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 **by Anelda van der Walt**

--- a/_posts/2016-03-28-pilot-spatial-data.md
+++ b/_posts/2016-03-28-pilot-spatial-data.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Workshops"
 title: "Hello, Spatio-temporal Data Carpentry"
 teaser: "News from the pilot of the spatial data Data Carpentry workshop"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 **By: Leah Wasser**  

--- a/_posts/2016-04-28-assessment-director-posting.md
+++ b/_posts/2016-04-28-assessment-director-posting.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Staff"
 title: "Hiring a Deputy Director of Assessment"
 teaser: "We're hiring a Deputy Director of Assessment to study the impact we are having"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 [Data Carpentry is hiring](http://www.datacarpentry.org/jobs/)!
 

--- a/_posts/2016-05-02-partnerships.md
+++ b/_posts/2016-05-02-partnerships.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Partnerships"
 title: "Announcing Partnerships"
 teaser: "There are now opportunities to be partners with Data Carpentry and Software Carpentry"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 ---
 
 We've been hearing of the interest of organizations to build local capacity for training  and to be able run both Data and [Software Carpentry](http://www.software-carpentry.org) workshops. **We are excited to announce that Data Carpentry and Software Carpentry are now offering joint partnerships!** These partnerships will give member organizations the benefits of running workshops from either the Software Carpentry or Data Carpentry community. At the Silver and above tiers there will also be instructor training and capacity building services provided.

--- a/_posts/2016-05-09-welcoming-community.md
+++ b/_posts/2016-05-09-welcoming-community.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Community"
 title: "A Welcoming Community"
 teaser: "We're committed to a friendly and respectful community for learning, teaching and contributing"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 authors: ["Tracy Teal", "Jonah Duckles"]
 ---
 

--- a/_posts/2016-05-10-new-associate-director.md
+++ b/_posts/2016-05-10-new-associate-director.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Staff"
 title: "Welcoming our new Associate Director"
 teaser: "Dr. Erin Becker starts as the new Data Carpentry Associate Director"
@@ -8,7 +8,8 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
+authors: ["Tracy Teal", "Erin Becker"]
 ---
 
 We are excited to announce that Dr. Erin Becker has accepted the position of

--- a/_posts/2016-05-17-r-instructor-training.md
+++ b/_posts/2016-05-17-r-instructor-training.md
@@ -1,5 +1,5 @@
 ---
-layout: page-fullwidth
+layout: post
 subheadline: "Training"
 title: "R Instructor Training"
 teaser: "Applications are now open for R instructor training"
@@ -8,7 +8,7 @@ header:
 categories:
    - blog
 comments: true
-show_meta: false
+show_meta: true
 authors: ["Greg Wilson"]
 ---
 Thanks to generous sponsorship from the [R Consortium](https://www.r-consortium.org/),


### PR DESCRIPTION
Updated YAML headers for all blog posts to use blog style, which includes metadata (date and author if given). This addresses point 2 in #88.