### PR TITLE
Blog post for assessment results

### DIFF
--- a/_posts/assessment-I
+++ b/_posts/assessment-I
@@ -1,0 +1,25 @@
+---
+layout: post
+subheadline: "Never, Sometimes, Usually, ALWAYS!"
+title: "Analysis of Data Carpentry Workshop Impact"
+teaser: "Data Carpentry workshops have a significant impact on learners."
+header:
+ image_fullwidth: "light-blue-wood-texture.jpg"
+categories:
+ 	- blog
+comments: true
+show_meta: true
+authors: ["Kari L. Jordan"]
+---
+
+
+It’s funny. When I first started working for Data Carpentry, I had never heard the phrase, “reproducible research”. I can tell you now that having attended a Software Carpentry workshop, Data Carpentry workshop, and a Software/Data Carpentry instructor training, I wish I had learned the skills we teach when I first began my PhD program.
+
+
+I even confessed to my colleagues that the data I left behind for up and coming grad students is so disorganized, I sent them an e-mail to apologize! This community has made a believer out of me, and for good reason: Our workshops work. I’ll prove it to you.
+
+
+Data Carpentry workshops have a significant impact on learners. Learners have expressed satisfaction with workshop content and appreciation for the caliber of their instructors. Learners have high means for research computing efficacy, and as Data Carpentry continues to offer more workshops, a shift in the perspective of how researchers view and use computational skills is sure to be realized. I believe Data Carpentry will continue to improve and expand our community of data-driven researchers.
+
+
+See for yourself, here are the [results](https://docs.google.com/document/d/1qafzCWZ7-9TgDhU5Hd5Gr2QLOpsQPjBDsfzdtg2mU40/edit) of the recent analysis of Data Carpentry’s post-workshop surveys. If you missed our community call, check out the [slidedeck](https://magic.piktochart.com/output/17303250-data-carpentry-community-call-assessment), and tweet us your thoughts @datacarpentry and @drkariljordan.


### PR DESCRIPTION
Blog post about the results of our post-workshop surveys per the editorial calendar. I am behind on analyzing the results in R, so I linked the report and slide deck in the blog post.