### PR TITLE
Add Semester Course Rollout and Collaborative Development Blog Post

### DIFF
--- a/_posts/2016-11-28-course-collaboration.md
+++ b/_posts/2016-11-28-course-collaboration.md
@@ -1,8 +1,8 @@
 ---
 layout: post
 subheadline: "Curriculum"
-title: "Data Carpentry Expanding Collaborative Lesson Development to Semester-long Courses"
-teaser: "Let's build on Data Carpentry's core strength of collaborative lesson development."
+title: "Collaborative Lesson Development for Semester-long Courses"
+teaser: "Building on Data Carpentry's core strength of collaborative lesson development."
 header:
  image_fullwidth: "light-blue-wood-texture.jpg"
 categories:
@@ -12,18 +12,20 @@ show_meta: true
 authors: ["Zack Brym"]
 ---
 
-> [When did you realize you belonged to the Carpentry community?][belonging]
+*[When did you realize you belonged to the Carpentry community?][belonging]*
 
 My first encounter with the Carpentry community was early in my PhD training,
 *way back when* Software Carpentry was teaching programming lessons using
 [brilliantly narrated videos][swc-shell-video]. I knew then that a basic
-understanding of computers was an important part of a strong career in science.
-What I didn't expect was to get inspired by a community of scientists and
-teachers that promotes openness and collaboration throughout their work. 
+understanding of computer programming was an important part of a strong career
+in science. What I didn't expect was to get inspired by a community of
+scientists and teachers that promotes openness and collaboration throughout
+their work. 
 
 Fast forward to the present... having just accepted my first faculty position
-in agroecology (*read big data scientist in agriculture*), I am very glad that I
-got involved in the Carpentry community.
+in agroecology (read, big data scientist in agriculture), I am very glad that I
+got involved in the Carpentry community. The Carpentries active and open
+approach to science and teaching has become my own.
 
 I taught laboratory courses throughout my PhD and quickly realized that the
 Carpentry model of active-learning resonated with my preference for teaching
@@ -41,7 +43,7 @@ and just formally [announced the first semester-long Data Carpentry Course][fork
 It doesn't take much to get involved. Instructors and students are encouraged to
 [provide feedback][feedback-contribute] for the course to help improve the content and clarity of the existing curriculum. Instructors are also welcome to
 [fork the course][fork-our-course] and use the general site structure and
-templates to develop their own course to expand the domains represented by the
+templates to develop their own course and expand the domains represented by the
 Carpentry community resources. 
 
 To get the collaborative course development rolling, instructors are encouraged

--- a/_posts/2016-11-28-course-collaboration.md
+++ b/_posts/2016-11-28-course-collaboration.md
@@ -1,0 +1,64 @@
+---
+layout: post
+subheadline: "Curriculum"
+title: "Data Carpentry Expanding Collaborative Lesson Development to Semester-long Courses"
+teaser: "Let's build on Data Carpentry's core strength of collaborative lesson development."
+header:
+ image_fullwidth: "light-blue-wood-texture.jpg"
+categories:
+   - blog
+comments: true
+show_meta: true
+authors: ["Zack Brym"]
+---
+
+> [When did you realize you belonged to the Carpentry community?][belonging]
+
+My first encounter with the Carpentry community was early in my PhD training,
+*way back when* Software Carpentry was teaching programming lessons using
+[brilliantly narrated videos][swc-shell-video]. I knew then that a basic
+understanding of computers was an important part of a strong career in science.
+What I didn't expect was to get inspired by a community of scientists and
+teachers that promotes openness and collaboration throughout their work. 
+
+Fast forward to the present... having just accepted my first faculty position
+in agroecology (*read big data scientist in agriculture*), I am very glad that I
+got involved in the Carpentry community.
+
+I taught laboratory courses throughout my PhD and quickly realized that the
+Carpentry model of active-learning resonated with my preference for teaching
+labs. There is something about engaging students in the learning process and
+giving them an opportunity to explore the lesson material. Insightfully, the
+Carpentry community elevated this active-learning process to include their
+instructors who are empowered to contribute to the [collaborative development of
+open source lesson materials][collaborative-dev]. For new instructors and 
+veteran Carpentry community members alike, now's an exciting time to be
+involved.
+
+Data Carpentry is working to expand their collaborative workshop development to
+include [curriculum innovation for college and university courses][curriculum-innovation]
+and just formally [announced the first semester-long Data Carpentry Course][fork-our-course].
+It doesn't take much to get involved. Instructors and students are encouraged to
+[provide feedback][feedback-contribute] for the course to help improve the content and clarity of the existing curriculum. Instructors are also welcome to
+[fork the course][fork-our-course] and use the general site structure and
+templates to develop their own course to expand the domains represented by the
+Carpentry community resources. 
+
+To get the collaborative course development rolling, instructors are encouraged
+to [contribute][feedback-contribute] exercises and lessons that can be used to
+customize the existing course structure to specific needs of various classes and
+programs. We use a ['reverse instructional design'][lesson-training] to develop
+our course materials and the exercises are the heart of that approach. Strong
+exercises clearly direct the instructional materials to be presented, facilitate 
+practice of the material, and assess learning.
+
+The Carpentry community continues to grow and we are excited for your
+participation. Let us know how we can help you get involved.
+
+[belonging]: http://www.datacarpentry.org/blog/belonging/
+[swc-shell-video]: https://www.youtube.com/watch?v=U3iNcBtycaQ&list=PLUQy4zfrctjH-FsjpIZDZ0NBznvF4FdNP
+[collaborative-dev]: https://jabberwocky.weecology.org
+[curriculum-innovation]: https://docs.google.com/document/d/1Xf6k3KOj9Joyubum_p465YH198JPGlG09F9_r00Mmcw/edit
+[fork-our-course]: https://jabberwocky.weecology.org/2016/11/14/fork-our-course-a-semester-long-data-carpentry-course-for-biologists/
+[feedback-contribute]: http://www.datacarpentry.org/semester-biology/docs/course/contributing/
+[lesson-training]: https://swcarpentry.github.io/instructor-training/19-lessons/


### PR DESCRIPTION
This blog is the result of a discussion with @ethanwhite, @tracykteal and myself following the recent blogs on Jabberwocky.weecology.org formally announcing the Data Carpentry Semester Course. The purpose is to generate some traffic from the DC Blog to Jabberwocky and the Semester Course site. 