### PR TITLE
Cleaning up mail links and inconsistent spacing/indentation.

### DIFF
--- a/pages/checkout.md
+++ b/pages/checkout.md
@@ -10,35 +10,35 @@ permalink: "/checkout/"
 After finishing the two day instructor training course, you will complete three short tasks in order to become a
 certified Data Carpentry instructor. Detailed information about these tasks can be found on the [instructor
 training website](http://swcarpentry.github.io/instructor-training/checkout/). Please use the checklist below
-as a quick reference, but be sure to read the detailed instructions first.  
+as a quick reference, but be sure to read the detailed instructions first.
 
-Tasks are listed in the order most of our instructor trainees complete the checkout process, but you can 
+Tasks are listed in the order most of our instructor trainees complete the checkout process, but you can
 complete them in any order.
 
 
-### Submit a Lesson Contribution  
-- [ ] Choose one of the Data Carpentry [lessons](/lessons/) to read in detail.  
-- [ ] Read the lesson carefully and work through the examples and exercises.  
-- [ ] On the lesson's GitHub repository (linked from the [lessons](/lessons/) page), look at existing issues and pull requests.  
-- [ ] Choose an existing issue or pull request to make a substantive comment on *or* identify a new issue or potential improvement.  
-- [ ] Submit your comment or issue on GitHub or by [email](lessons@software-carpentry.org). 
-- [ ] If you make your contribution through GitHub, send an email to [lessons@software-carpentry.org](mailto: lessons@software-carpentry.org) with a link to your contribution.  
+### Submit a Lesson Contribution
+- [ ] Choose one of the Data Carpentry [lessons](/lessons/) to read in detail.
+- [ ] Read the lesson carefully and work through the examples and exercises.
+- [ ] On the lesson's GitHub repository (linked from the [lessons](/lessons/) page), look at existing issues and pull requests.
+- [ ] Choose an existing issue or pull request to make a substantive comment on *or* identify a new issue or potential improvement.
+- [ ] Submit your comment or issue on GitHub or by [email](mailto:lessons@software-carpentry.org).
+- [ ] If you make your contribution through GitHub, send an email to [lessons@software-carpentry.org](mailto:lessons@software-carpentry.org) with a link to your contribution.
 
-### Participate in an Online Discussion Session  
-- [ ]  Sign up for a discussion session on [this Etherpad](http://pad.software-carpentry.org/instructor-discussion). 
+### Participate in an Online Discussion Session
+- [ ] Sign up for a discussion session on [this Etherpad](http://pad.software-carpentry.org/instructor-discussion).
 - [ ] Prepare to ask questions about lessons, workshop logistics, or anything you would like to know about teaching with Data Carpentry.
-- [ ]  Attend your selected session and actively participate in the discussion.
+- [ ] Attend your selected session and actively participate in the discussion.
 
 
-### Teach a Short Demonstration Lesson  
-- [ ] Sign up for a teaching demonstration session on [this Etherpad](http://pad.software-carpentry.org/teaching-demos).   
-- [ ] Ensure you have a Google Hangouts account and that it is working properly.  
+### Teach a Short Demonstration Lesson
+- [ ] Sign up for a teaching demonstration session on [this Etherpad](http://pad.software-carpentry.org/teaching-demos).
+- [ ] Ensure you have a Google Hangouts account and that it is working properly.
 - [ ] Be prepared to teach any 5-minute section of your selected lesson module from the Data Carpentry [curriculum](/lessons/).
-- [ ] Attend your selected session and actively participate in giving feedback to other instructors.  
+- [ ] Attend your selected session and actively participate in giving feedback to other instructors.
 
 After you complete your lesson contribution, online discussion and teaching demonstration, we will send you
-information about how to add yourself to our teaching roster and how to be contacted to teach workshops. 
+information about how to add yourself to our teaching roster and how to be contacted to teach workshops.
 We are excited to have you on the team and look forward to teaching with you!
 
-If you have any questions about the checkout process, please contact us at 
-[lessons@software-carpentry.org](mailto: lessons@software-carpentry.org).
+If you have any questions about the checkout process, please contact us at
+[lessons@software-carpentry.org](mailto:lessons@software-carpentry.org).


### PR DESCRIPTION
1.  Alex Williams (UCSF) noticed that the mail links weren't working: some didn't include `mailto` and others had a space between `mailto:` and the address. Fixed.
2.  Indentation of list items was inconsistent.
3.  Some lines had trailing spaces, which made rendering inconsistent.

@tracykteal please review and merge (I'm unable to assign).