### PR TITLE
fix URL to SWC/DC teaching practices

### DIFF
--- a/pages/equipment-checklist.md
+++ b/pages/equipment-checklist.md
@@ -16,7 +16,7 @@ You will usually need:
 - [ ] Any necessary adaptors  
 - [ ] Extension cords and power strips  
 - [ ] Guest log-ins and passwords for wifi if needed  
-- [ ] Sticky notes (two colors) - see description of how these are used [here](http://swcarpentry.github.io/instructor-training/16-practices/)  
+- [ ] Sticky notes (two colors) - see description of how these are used [here](http://swcarpentry.github.io/instructor-training/15-practices/)  
 - [ ] Name tags and pens
 - [ ] Sign-in forms  
 - [ ] Photo release forms (if required by your institution)  

--- a/pages/instructor-checklist.md
+++ b/pages/instructor-checklist.md
@@ -11,7 +11,7 @@ Each instructor is responsible for preparing to teach their section(s) of the wo
 
 ## Before the workshop:  
 - [ ] Coordinate with the lead instructor to decide who is teaching what, and in which order  
-- [ ] If your workshop is self-organized, and you are not a certified Data Carpentry instructor, meet with the lead instructor to be trained in [Data Carpentry’s teaching practices](http://swcarpentry.github.io/instructor-training/16-practices/)  
+- [ ] If your workshop is self-organized, and you are not a certified Data Carpentry instructor, meet with the lead instructor to be trained in [Data Carpentry’s teaching practices](http://swcarpentry.github.io/instructor-training/15-practices/)  
 - [ ] Test your installation instructions to make sure they work as expected  
 - [ ] Read the [lesson(s)](http://www.datacarpentry.org/lessons/) you are going to teach in detail  
 - [ ] If there is an [instructor’s guide](/for-instructors/#contribute-to-instructor-notes) for your lesson, read it carefully  
@@ -20,8 +20,8 @@ Each instructor is responsible for preparing to teach their section(s) of the wo
 
 ## At the workshop:  
 - [ ] Remind your learners about the [Code of Conduct](http://www.datacarpentry.org/code-of-conduct/)  
-- [ ] Remind learners to use their sticky notes to give feedback - see description of how these are used [here](http://swcarpentry.github.io/instructor-training/16-practices/)  
-- [ ] Get feedback with minute cards at lunch and end of each day - see description of minute cards [here](http://swcarpentry.github.io/instructor-training/16-practices/)
+- [ ] Remind learners to use their sticky notes to give feedback - see description of how these are used [here](http://swcarpentry.github.io/instructor-training/15-practices/)  
+- [ ] Get feedback with minute cards at lunch and end of each day - see description of minute cards [here](http://swcarpentry.github.io/instructor-training/15-practices/)
 
 ## After the workshop:  
 - [ ] Take part in an [instructor discussion session](http://pad.software-carpentry.org/instructor-discussion)  

--- a/pages/self-org-lead.md
+++ b/pages/self-org-lead.md
@@ -26,7 +26,7 @@ Usually for a self-organized workshop, the lead instructor is also the host. For
 - [ ] [Recruit helpers](/email-templates/#recruiting-helpers) (at least 1 per 12 participants)  
 - [ ] [Advertise](/email-templates/#advertising-your-workshop) your workshop  
 - [ ] Pay the [self-organized workshop fee](/self-organized-workshops/#fees-for-self-organized-workshops)  
-- [ ] Train your co-instructors [how to use Data Carpentry practices](http://swcarpentry.github.io/instructor-training/16-practices/) to teach  
+- [ ] Train your co-instructors [how to use Data Carpentry practices](http://swcarpentry.github.io/instructor-training/15-practices/) to teach  
 - [ ] [Prepare to teach your material](/instructor-checklist/)  
 - [ ] [Email learners](/email-templates/#email-learners-before-workshop) to remind them about workshop location, timing and installation requirements and send out the pre-workshop survey  
 - [ ] Gather [required materials](/equipment-checklist/)  


### PR DESCRIPTION
Seems there was a reorg of the SWC Instructor Training pages (which are excellent!): 

old: http://swcarpentry.github.io/instructor-training/16-practices/       
new:  http://swcarpentry.github.io/instructor-training/15-practices/    