### PR TITLE
Update genomics lesson page

### DIFF
--- a/pages/lessons.md
+++ b/pages/lessons.md
@@ -104,28 +104,34 @@ There are two versions of this workshop **Genomics Workshop with Pipeline Workfl
     <th>Maintainer(s)</th>
   </tr>
   <tr>
+    <td>Project organization and management</td>
+    <td><a href="{{site.dc_website_url}}/organization-genomics" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+    <td><a href="{{site.dc_github_repo_url}}/organization-genomics/" target="_blank" class="icon-github" title="icon-github"></a></td>
+    <td>Manny Corpas, Roselyn Lemus, Yujuan Gui, Mateusz Kuzak</td>
+</tr>
+  <tr>
     <td>Introduction to cloud computing for genomics</td>
     <td><a href="{{site.dc_website_url}}/cloud-genomics" target="_blank" class="icon-browser" title="icon-browser"></a></td>
    <td><a href="{{site.dc_github_repo_url}}/cloud-genomics/" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td>Bob Freeman</td>
+    <td>Bob Freeman, Darya Vanichkina, Kevin Buckley, Amanda Charbonneau</td>
   </tr>
   <tr>
     <td>Introduction to the command line</td>
-    <td><a href="{{site.dc_website_url}}/shell-genomics/lessons/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+    <td><a href="{{site.dc_website_url}}/shell-genomics/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
    <td><a href="{{site.dc_github_repo_url}}/shell-genomics/" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td>Sheldon McKay, Karen Cranston</td>
+    <td>Shichen Wang, Anita Schürch, Bastian Greshak, Sue McClatchy</td>
   </tr>
   <tr>
     <td>Data wrangling and processing</td>
-    <td><a href="{{site.dc_github_repo_url}}/wrangling-genomics/tree/gh-pages/lessons" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+    <td><a href="{{site.dc_website_url}}/wrangling-genomics/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
    <td><a href="{{site.dc_github_repo_url}}/wrangling-genomics/" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td>Sheldon McKay, Karen Cranston</td>
+    <td>Josh Herr, Ming Tang, Lex Nederbragt, Fotis Psomopoulos</td>
   </tr>
   <tr>
     <td>Data analysis and visualization in R</td>
     <td><a href="{{site.dc_website_url}}/R-genomics/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="{{site.dc_github_repo_url}}/R-genomics/" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td>Naupaka Zimmerman, Jason Williams, Meeta Mistry</td>
+    <td>Naupaka Zimmerman, Ahmed Moustafa, Krzysztof Poterlowicz, Jason Williams</td>
   </tr>
 </table>
 


### PR DESCRIPTION
This PR updates the maintainers list, lesson links and lesson list (adds project management and organization) for the genomics lessons. @tracykteal - I've replaced the maintainers list with those who filled out the maintainers application and survey, however I recognize that some of the previous maintainers may wish to stay maintainers for their lessons. Could you please ensure that I haven't left off anyone who would like to stay a maintainer before merging?