### PR TITLE
Twitter cards

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,8 @@ url: "http://www.datacarpentry.org"
 #url: "http://0.0.0.0:4000/"
 baseurl: ""
 
+twitter_name: @datacarpentry
+
 # This is for the editing function in _/includes/improve_content.html
 # Leave it empty if your site is not on GitHub/GitHub Pages
 improve_content: https://github.com/datacarpentry/datacarpentry.github.io/edit/gh-pages

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ url: "http://www.datacarpentry.org"
 #url: "http://0.0.0.0:4000/"
 baseurl: ""
 
-twitter_name: @datacarpentry
+twitter_name: "@datacarpentry"
 
 # This is for the editing function in _/includes/improve_content.html
 # Leave it empty if your site is not on GitHub/GitHub Pages

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
 	<title>{% if page.meta_title %}{{ page.meta_title }}{% elsif page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 	<link rel="stylesheet" href="{{ site.url }}/assets/css/styles_feeling_responsive.css">
 	<script src="{{ site.url }}/assets/js/modernizr.min.js"></script>
-	
+
   <script>
     WebFontConfig = {
       google: { families: [ 'Lato:400,700,400italic:latin', 'Volkhov::latin' ] }
@@ -34,17 +34,17 @@
 	<meta name="twitter:site" content="{{ site.twitter_name }}">
 	<meta name="twitter:domain" content="{{ site.baseurl }}">
 	{% if page.excerpt %}
-	<meta name="twitter:description" content="{{ page.teaser | strip_html | truncate: 200 | remove: '<p>' | remove: '</p>' }}">
+	<meta name="twitter:description" content="{{ page.teaser | markdownify | strip_html | truncate: 200 | remove: '<p>' | remove: '</p>' }}">
 	{% else %}
-	<meta name="twitter:description" content="{{ page.content | strip_html | truncate: 200 | remove: '<p>' | remove: '</p>' }}">
+	<meta name="twitter:description" content="{{ page.content | markdownify | strip_html | truncate: 200 | remove: '<p>' | remove: '</p>' }}">
 	{% endif %}
 	<meta name="twitter:image" content="https://github.com/datacarpentry/logos/blob/master/DC1_logo_small.png?raw=true">
-	
-	
+
+
   {% if site.google_site_verification %}<meta name="google-site-verification" content="{{ site.google_site_verification}}" />{% endif %}
 	{% if site.bing_webmastertools_id %}<meta name="msvalidate.01" content="{{ site.bing_webmastertools_id }}" />{% endif %}
 	{% if page.meta_description %}<meta name="description" content="{{ page.meta_description | strip_html | escape }}"/>{% elsif page.teaser %}<meta name="description" content="{{ page.teaser | strip_html | escape }}"/>{% elsif site.description %}<meta name="description" content="{{ site.description | strip_html | escape }}"/>{% endif %}
-	
+
 	{% if site.google_author %}<link rel="author" href="{{ site.google_author }}"/>{% endif %}
 
 	{% include favicon %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,6 +28,19 @@
     <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic%7cVolkhov' rel='stylesheet' type='text/css'>
   </noscript>
 
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:url" content="{{ site.url }}{{ page.url }}">
+	<meta name="twitter:title" content="{{ page.title }}">
+	<meta name="twitter:site" content="{{ site.twitter_name }}">
+	<meta name="twitter:domain" content="{{ site.baseurl }}">
+	{% if page.excerpt %}
+	<meta name="twitter:description" content="{{ page.teaser | strip_html | truncate: 200 | remove: '<p>' | remove: '</p>' }}">
+	{% else %}
+	<meta name="twitter:description" content="{{ page.content | strip_html | truncate: 200 | remove: '<p>' | remove: '</p>' }}">
+	{% endif %}
+	<meta name="twitter:image" content="https://github.com/datacarpentry/logos/blob/master/DC1_logo_small.png?raw=true">
+	
+	
   {% if site.google_site_verification %}<meta name="google-site-verification" content="{{ site.google_site_verification}}" />{% endif %}
 	{% if site.bing_webmastertools_id %}<meta name="msvalidate.01" content="{{ site.bing_webmastertools_id }}" />{% endif %}
 	{% if page.meta_description %}<meta name="description" content="{{ page.meta_description | strip_html | escape }}"/>{% elsif page.teaser %}<meta name="description" content="{{ page.teaser | strip_html | escape }}"/>{% elsif site.description %}<meta name="description" content="{{ site.description | strip_html | escape }}"/>{% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,7 +33,7 @@
 	<meta name="twitter:title" content="{{ page.title }}">
 	<meta name="twitter:site" content="{{ site.twitter_name }}">
 	<meta name="twitter:domain" content="{{ site.baseurl }}">
-	{% if page.excerpt %}
+	{% if page.teaser %}
 	<meta name="twitter:description" content="{{ page.teaser | markdownify | strip_html | truncate: 200 | remove: '<p>' | remove: '</p>' }}">
 	{% else %}
 	<meta name="twitter:description" content="{{ page.content | markdownify | strip_html | truncate: 200 | remove: '<p>' | remove: '</p>' }}">


### PR DESCRIPTION
This should be everything we need for working Twitter cards at DC as well. I used the `page.teaser` instead of `page.excerpt`, so @weaverbel you probably won't have to add excerpts here. Once this is merged, you can force Twitter to refresh the card cache by entering each page you want a new card generated for here: https://cards-dev.twitter.com/validator