### PR TITLE
Added checklist item re: emergency contact info

### DIFF
--- a/pages/hosted-lead.md
+++ b/pages/hosted-lead.md
@@ -23,7 +23,7 @@ The lead instructor is also responsible for preparing to teach the material - se
 - [ ] Send your website repository’s URL to the [Data Carpentry workshop coordinator](mailto:team@carpentries.org) (team@carpentries.org)  
 - [ ] Assist the workshop host with [recruiting helpers](/email-templates/#recruiting-helpers) (at least 1 per 12 participants)  
 - [ ] Coordinate with the host to ensure the workshop is [accessible](/accessibility/)
-- [ ] Coordinate with the host to obtain contact information in case of emergency (e.x. local authorities, building security)
+- [ ] Coordinate with the host to obtain contact information in case of emergency (e.g. local authorities, building security)
 - [ ] [Prepare to teach your material](/instructor-checklist/) 
 - [ ] [Email learners](/email-templates/#email-learners-before-workshop) to remind them about workshop location, timing and installation requirements and send out the pre-workshop survey 
 - [ ] Check with the host to make sure they have the necessary [equipment](/equipment-checklist/), especially sticky notes

--- a/pages/hosted-lead.md
+++ b/pages/hosted-lead.md
@@ -22,7 +22,8 @@ The lead instructor is also responsible for preparing to teach the material - se
 - [ ] [Set up your workshop website](https://github.com/datacarpentry/workshop-template)  
 - [ ] Send your website repository’s URL to the [Data Carpentry workshop coordinator](mailto:team@carpentries.org) (team@carpentries.org)  
 - [ ] Assist the workshop host with [recruiting helpers](/email-templates/#recruiting-helpers) (at least 1 per 12 participants)  
-- [ ] Coordinate with the host to ensure the workshop is [accessible](/accessibility/)  
+- [ ] Coordinate with the host to ensure the workshop is [accessible](/accessibility/)
+- [ ] Coordinate with the host to obtain contact information in case of emergency (e.x. local authorities, building security)
 - [ ] [Prepare to teach your material](/instructor-checklist/) 
 - [ ] [Email learners](/email-templates/#email-learners-before-workshop) to remind them about workshop location, timing and installation requirements and send out the pre-workshop survey 
 - [ ] Check with the host to make sure they have the necessary [equipment](/equipment-checklist/), especially sticky notes


### PR DESCRIPTION
As per discussion in a recent trainer training discussion, added to the 'Before the Workshop' checklist the need for instructors to have access to emergency contact information in the case of fire, medical emergency, etc. occurring while the host is not present.