### PR TITLE
remove fasttrack

### DIFF
--- a/pages/involved-instructor.md
+++ b/pages/involved-instructor.md
@@ -17,40 +17,17 @@ schedule, travel interests and availability.
 
 ### How to become an instructor
 
-_If you are already a Software Carpentry instructor or experienced educator, see information on the [FastTrack](#data-carpentry-fasttrack-instructors-application) program below._
-
-The Software Carpentry Foundation runs the Instructor Training course for both Software and Data Carpentry.
+Data and Software Carpentry run a joint Instructor Training course.
 
 There are two steps to becoming an instructor.  
 
-1. **Take a Software Carpentry Foundation instructor training course**   
+1. **Take a Instructor Training course**   
 The training course runs over two full days and covers the basics of educational psychology, instructional design, and how to apply both to teaching Data Carpentry and Software Carpentry materials. For a preview of materials - see the [instructor training course page](http://carpentries.github.io/instructor-training/).
 
 2. **Complete the checkout process**  
 You must complete three short tasks after the course in order to complete certification. These tasks are described in detail [here](http://carpentries.github.io/instructor-training/checkout/) and take a total of approximately 8-10 hours. Once you've read the detailed instructions, please use our [simplified checklist](/checkout/) to keep track of your progress.
 
 *Most of our instructors are trained through organizational agreements with affiliated institutions. If you have been asked to provide information associated with this type of training, please fill in [this form](https://amy.software-carpentry.org/workshops/request_training/). If you are not affiliated with one of our partner organizations, we offer limited scholarships to attend online instructor training. Please fill out the form above to indicate your interest in participating in an upcoming instructor training.*
-
-<!--
-If you are going through instructor training and need more information, please see [information]() in the [For Instructors]() section.
--->
-
----
-
-### Data Carpentry Instructors FastTrack Application
-
-If you are interested in teaching people new to computation and data analysis,
-have the skills to teach
-introductory R, Python or SQL and demonstrated teaching experience as a Software
-Carpentry instructor or as an instructor in another capacity, we would love to have you as an instructor!
-
-- See more information in this blog post: [http://www.datacarpentry.org/blog/fasttrack/](http://www.datacarpentry.org/blog/fasttrack/) 
-
-If you meet the requirements above, you can go through the FastTrack program rather than completing all of the normal requirements. Although the initial deadline was in November, we are still happily accepting FastTrack applicants. 
-
-- Please fill out the FastTrack application:  
- [http://www.datacarpentry.org/fasttrack/](http://www.datacarpentry.org/fasttrack/)  
-- and sign up for an upcoming onboarding meeting on [http://pad.software-carpentry.org/data-carpentry-instructors](http://pad.software-carpentry.org/data-carpentry-instructors)  
 
 We are interested in instructors from all domains of research, and are particularly
 working to grow our instructor pool in social sciences and digital humanities.


### PR DESCRIPTION
The FastTrack program is out of date. SWC instructors are qualified to teach DC workshops.

@tracykteal 