### PR TITLE
Fix instructor guide dead link

### DIFF
--- a/pages/lessons.md
+++ b/pages/lessons.md
@@ -70,7 +70,7 @@ The workshop can be taught using R or Python as the base language.
     <td>Data Analysis and Visualization in R</td>
     <td><a href="{{site.dc_github_site_url}}/R-ecology-lesson/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="{{site.dc_github_repo_url}}/R-ecology-lesson/" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.dc_github_repo_url}}/R-ecology-lesson/blob/gh-pages/instructor-notes.md" target="_blank" class="icon-github" title="icon-github"></a></td>
+    <td><a href="{{site.dc_github_site_url}}/R-ecology-lesson/instructor-notes" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td>François Michonneau, Auriel Fournier</td>
   </tr>
   <tr>


### PR DESCRIPTION
On the live site, the link currently points to [https://github.com/datacarpentry/R-ecology-lesson/blob/gh-pages/instructor-notes.md](https://github.com/datacarpentry/R-ecology-lesson/blob/gh-pages/instructor-notes.md) which is a 404. This should change it to [http://www.datacarpentry.org/R-ecology-lesson/instructor-notes](http://www.datacarpentry.org/R-ecology-lesson/instructor-notes).