### PR TITLE
Add change clause

### DIFF
--- a/pages/code-of-conduct.md
+++ b/pages/code-of-conduct.md
@@ -7,29 +7,29 @@ header:
 permalink: "/code-of-conduct/"
 ---
 
-Data Carpentry and Software Carpentry are community organizations. 
-We value the involvement of everyone in this community - learners, instructors, hosts, developers, steering
-committee members and staff. We are committed to creating a friendly and respectful place for learning, 
+The Carpentries is a community-led project.
+We value the involvement of everyone in this community - learners, instructors, hosts, developers, executive council members and staff. 
+We are committed to creating a friendly and respectful place for learning, 
 teaching and contributing. All participants in our events and communications are expected to show respect 
 and courtesy to others.  
  
-To make clear what is expected, everyone participating in Data Carpentry and Software Carpentry activities 
+To make clear what is expected, everyone participating in Carpentry activities 
 is required to conform to the following Code of Conduct. This code of conduct applies to all spaces managed by
-Data Carpentry and Software Carpentry including, but not limited to, workshops, email lists, online forums and 
+The Carpentries including, but not limited to, workshops, email lists, online forums and 
 on GitHub. Workshop hosts are expected to assist with enforcement of the Code of Conduct.  
 
-If you believe someone is violating the Code of Conduct we ask that you report it to the joint Data/Software Carpentry (“the Carpentries”) Policy subcommittee by emailing [policy@carpentries.org](mailto:policy@carpentries.org) or 
+If you believe someone is violating the Code of Conduct we ask that you report it to The Carpentry Policy subcommittee by emailing [policy@carpentries.org](mailto:policy@carpentries.org) or 
 C. MacDonnell at [confidential@carpentries.org](mailto:confidential@carpentries.org), and if the violation occurs during a
 workshop or other in-person event,
 by contacting the host and/or coordinator. All reports will be kept confidential.  When possible, please follow
-the reporting guidelines detailed [here](/CoC-reporting/). All reports will be reviewed by the Conduct Policy
+the reporting guidelines detailed [here](/CoC-reporting/). All reports will be reviewed by the Policy
 subcommittee. A detailed enforcement policy can be found [here](/CoC-enforcement/).  
 
 <hr>
 
 ### Code of Conduct
 
-Data Carpentry and Software Carpentry are dedicated to providing a welcoming and supportive environment for all
+The Carpentries are dedicated to providing a welcoming and supportive environment for all
 people, regardless of background or identity. However, we recognise that some groups in our community are subject
 to historical and ongoing discrimination, and may be vulnerable or disadvantaged. Membership in such a specific
 group can be on the basis of characteristics such as gender, sexual orientation, disability, physical
@@ -58,11 +58,13 @@ exhaustive but rather as a guide to make it easier to enrich all of us and the c
 participate. All Carpentry interactions should be professional regardless of location: harassment is prohibited
 whether it occurs on- or offline, and the same standards apply to both.  
 
-Enforcement of the Code of Conduct will be respectful and not include any harassing behaviors.  
+Enforcement of the Code of Conduct will be respectful and not include any harassing behaviors. Any changes to the meaning of this 
+Code of Conduct must be approved by majority vote of both the Policy subcommittee and The Carpentries Executive Council. 
+The Carpentry Community will be informed of these changes and any concerns that are raised will be discussed by the Policy committee.  
 
 Thank you for helping make this a welcoming, friendly community for all.  
 
-This code of conduct is an adaptation of the one used by the Software Carpentry Foundation and is a modified
+This code of conduct is a modified
 version of that used by PyCon, which in turn is forked from a template written by the Ada Initiative and hosted
 on the Geek Feminism Wiki. Contributors to this document: Adam Obeng, Aleksandra Pawlik, Bill Mills, Carol
 Willing, Erin Becker, Hilmar Lapp, Kara Woo, Karin Lagesen, Pauline Barmby, Sheila Miguez, Simon Waldman, Tracy


### PR DESCRIPTION
The Policy Committee previous approved addition of the clause:

"Any changes to the meaning of the Code of Conduct must be approved by majority vote of both the Policy subcommittee and The Carpentries Executive Council. The Carpentry Community will be informed of these changes and any concerns that are raised will be discussed by the Policy committee."

This PR implements this change and updates language to refer to The Carpentries.