### PR TITLE
Update workshop-template links to swcarpentry repo

### DIFF
--- a/pages/hosted-lead.md
+++ b/pages/hosted-lead.md
@@ -19,7 +19,7 @@ The lead instructor is also responsible for preparing to teach the material - se
 ## Before the workshop:  
 - [ ] With the workshop host and your co-instructors, decide on your [curriculum](/workshops/), the order of lessons and who will teach each lesson  
 - [ ] Create an Etherpad for your workshop at http://pad.software-carpentry.org/YYYY-MM-DD-site (where "YYYY-MM-DD-site" is the ID of your workshop)
-- [ ] [Set up your workshop website](https://github.com/datacarpentry/workshop-template)  
+- [ ] [Set up your workshop website](https://github.com/swcarpentry/workshop-template)  
 - [ ] Send your website repository’s URL to the [Data Carpentry workshop coordinator](mailto:team@carpentries.org) (team@carpentries.org)  
 - [ ] Assist the workshop host with [recruiting helpers](/email-templates/#recruiting-helpers) (at least 1 per 12 participants)  
 - [ ] Coordinate with the host to ensure the workshop is [accessible](/accessibility/)

--- a/pages/self-org-lead.md
+++ b/pages/self-org-lead.md
@@ -21,7 +21,7 @@ Usually for a self-organized workshop, the lead instructor is also the host. For
 - [ ] Ensure your venue is [accessible](/accessibility/)  
 - [ ] Create an Etherpad for your workshop at http://pad.software-carpentry.org/YYYY-MM-DD-site (where "YYYY-MM-DD-site" is the ID of your workshop)
 - [ ] Set up your workshop registration page  
-- [ ] [Set up your workshop website](https://github.com/datacarpentry/workshop-template)  
+- [ ] [Set up your workshop website](https://github.com/swcarpentry/workshop-template)  
 - [ ] Send your website repository’s URL to the [Data Carpentry workshop coordinator](mailto:team@carpentries.org) (team@carpentries.org)  
 - [ ] [Recruit helpers](/email-templates/#recruiting-helpers) (at least 1 per 12 participants)  
 - [ ] [Advertise](/email-templates/#advertising-your-workshop) your workshop  


### PR DESCRIPTION
The checklists for organizing workshops point to the datacarpentry/workshop-template repository, but this repository is deprecated. This PR updates the checklist to point to the swcarpentry/workshop-template repository. I didn't update any links in old blog posts.