### PR TITLE
Add Social Science lessons to lessons page

### DIFF
--- a/pages/lessons.md
+++ b/pages/lessons.md
@@ -22,8 +22,8 @@ Data Carpentry workshops are domain-specific, so that we are teaching researcher
 
 ## Workshop materials under development or consideration
 
-- [Geospatial data curriculum](#geospatial-curriculum)
 - [Social science curriculum](#social-science-curriculum)
+- [Geospatial data curriculum](#geospatial-curriculum)
 - [Digital humanities curriculum](#dh-curriculum)
 - [Image analysis curriculum](#image-curriculum)
 - [Economics curriculum](#economics-curriculum)

--- a/pages/lessons.md
+++ b/pages/lessons.md
@@ -204,44 +204,58 @@ These materials are scheduled for release and will be available for teaching in 
 <table class="table table-striped">
     <tr>
         <th>Lesson</th>
-        <th>Material</th>
+        <th>Site</th>
         <th>Repository</th>
+        <th>Reference</th>
+        <th>Instructor Guide</th>
         <th>Maintainer(s)</th>
-    </tr>
+</tr>
     <tr>
         <td>Social Science Workshop Homepage</td>
         <td><a href="http://www.datacarpentry.org/socialsci-workshop/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
         <td><a href="{{site.dc_github_repo_url}}/socialsci-workshop/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td>&nbsp;</td>
+        <td>&nbsp;</td>
         <td>TBA</td>
     </tr>
     <tr>
         <td>Data Organization in Spreadsheets for Social Scientists</td>
         <td><a href="http://www.datacarpentry.org/spreadsheets-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
         <td><a href="{{site.dc_github_repo_url}}/spreadsheets-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td><a href="{{site.dc_github_site_url}}/spreadsheets-socialsci/reference/" target="_blank" class="icon-eye" title="Reference for spreadsheets social science lesson"></a></td>
+        <td><a href="{{site.dc_github_site_url}}/spreadsheets-socialsci/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor guide for spreadsheets social science lesson"></a></td>
         <td>TBA</td>
     </tr>
     <tr>
         <td>Data Cleaning with OpenRefine for Social Scientists</td>
         <td><a href="http://www.datacarpentry.org/openrefine-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
         <td><a href="{{site.dc_github_repo_url}}/openrefine-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td><a href="{{site.dc_github_site_url}}/openrefine-socialsci/reference/" target="_blank" class="icon-eye" title="Reference for OpenRefine social science lesson"></a></td>
+        <td><a href="{{site.dc_github_site_url}}/openrefine-socialsci/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor guide for OpenRefine social science lesson"></a></td>
         <td>TBA</td>
     </tr>
     <tr>
         <td>Data Management with SQL for Social Scientists</td>
         <td><a href="http://www.datacarpentry.org/sql-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
         <td><a href="{{site.dc_github_repo_url}}/sql-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td><a href="{{site.dc_github_site_url}}/sql-socialsci/reference/" target="_blank" class="icon-eye" title="Reference for SQL social science lesson"></a></td>
+        <td><a href="{{site.dc_github_site_url}}/sql-socialsci/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor guide for SQL social science lesson"></a></td>
         <td>TBA</td>
     </tr>
     <tr>
         <td>Data Analysis and Visualization with R for Social Scientists</td>
         <td><a href="http://www.datacarpentry.org/r-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
         <td><a href="{{site.dc_github_repo_url}}/r-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td><a href="{{site.dc_github_site_url}}/r-socialsci/reference/" target="_blank" class="icon-eye" title="Reference for R social science lesson"></a></td>
+        <td><a href="{{site.dc_github_site_url}}/r-socialsci/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor guide for R social science lesson"></a></td>
         <td>TBA</td>
     </tr>
     <tr>
         <td>Data Analysis and Visualization with Python for Social Scientists</td>
         <td><a href="http://www.datacarpentry.org/python-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
         <td><a href="{{site.dc_github_repo_url}}/python-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td><a href="{{site.dc_github_site_url}}/python-socialsci/reference/" target="_blank" class="icon-eye" title="Reference for Python social science lesson"></a></td>
+        <td><a href="{{site.dc_github_site_url}}/python-socialsci/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor guide for Python social science lesson"></a></td>
         <td>TBA</td>
     </tr>
 
@@ -261,22 +275,28 @@ Join the [geospatial curriculum email list](https://groups.google.com/a/carpentr
 #### Lessons
 
 <table class="table table-striped">
-  <tr>
-    <th>Lesson</th>
-    <th>Material</th>
-    <th>Repository</th>
-    <th>Maintainer(s)</th>
-  </tr>
+    <tr>
+        <th>Lesson</th>
+        <th>Site</th>
+        <th>Repository</th>
+        <th>Reference</th>
+        <th>Instructor Guide</th>
+        <th>Maintainer(s)</th>
+    </tr>
   <tr>
     <td>Introduction to Geospatial Data with R</td>
     <td><a href="http://www.datacarpentry.org/R-spatial-raster-vector-lesson/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="{{site.dc_github_repo_url}}/R-spatial-raster-vector-lesson/" target="_blank" class="icon-github" title="icon-github"></a></td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
     <td>Leah Wasser, Joseph Stachelek</td>
   </tr>
   <tr>
     <td>Introduction to Geospatial data</td>
     <td><a href="http://www.datacarpentry.org/r-spatial-data-management-intro/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="{{site.dc_github_repo_url}}/r-spatial-data-management-intro/" target="_blank" class="icon-github" title="icon-github"></a></td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
     <td>Leah Wasser, Joseph Stachelek</td>
   </tr>
 

--- a/pages/lessons.md
+++ b/pages/lessons.md
@@ -195,9 +195,62 @@ The course is accessible to:
 
 ## Materials under development
 
+### <a id="social-science-curriculum"></a> Social Science Curriculum
+
+These materials are scheduled for release and will be available for teaching in May 2018. 
+
+#### Lessons
+
+<table class="table table-striped">
+    <tr>
+        <th>Lesson</th>
+        <th>Material</th>
+        <th>Repository</th>
+        <th>Maintainer(s)</th>
+    </tr>
+    <tr>
+        <td>Social Science Workshop Homepage</td>
+        <td><a href="http://www.datacarpentry.org/socialsci-workshop/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+        <td><a href="{{site.dc_github_repo_url}}/socialsci-workshop/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td>TBA</td>
+    </tr>
+    <tr>
+        <td>Data Organization in Spreadsheets for Social Scientists</td>
+        <td><a href="http://www.datacarpentry.org/spreadsheets-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+        <td><a href="{{site.dc_github_repo_url}}/spreadsheets-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td>TBA</td>
+    </tr>
+    <tr>
+        <td>Data Cleaning with OpenRefine for Social Scientists</td>
+        <td><a href="http://www.datacarpentry.org/openrefine-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+        <td><a href="{{site.dc_github_repo_url}}/openrefine-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td>TBA</td>
+    </tr>
+    <tr>
+        <td>Data Management with SQL for Social Scientists</td>
+        <td><a href="http://www.datacarpentry.org/sql-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+        <td><a href="{{site.dc_github_repo_url}}/sql-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td>TBA</td>
+    </tr>
+    <tr>
+        <td>Data Analysis and Visualization with R for Social Scientists</td>
+        <td><a href="http://www.datacarpentry.org/r-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+        <td><a href="{{site.dc_github_repo_url}}/r-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td>TBA</td>
+    </tr>
+    <tr>
+        <td>Data Analysis and Visualization with Python for Social Scientists</td>
+        <td><a href="http://www.datacarpentry.org/python-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+        <td><a href="{{site.dc_github_repo_url}}/python-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
+        <td>TBA</td>
+    </tr>
+
+</table>
+
+
 ### <a id="geospatial-curriculum"></a> Geospatial Data Workshop
 
-*These lessons are under development and will be ready for broader teaching in mid 2018*
+These materials are scheduled for release and will be available for teaching in July 2018. 
 
 #### Overview
 
@@ -230,11 +283,6 @@ Join the [geospatial curriculum email list](https://groups.google.com/a/carpentr
 
   </table>
 
-### <a id="social-science-curriculum"></a> Social Science Curriculum
-
-Social science curriculum is under initial development with the University of Manchester.
-
-Alpha release and pilot workshops planned for early 2018. If you are interested in following or being involved in development of this curriculum, please sign up for the [social-science-curriculum email list](https://groups.google.com/a/carpentries.org/forum/#!forum/social-science-curriculum)
 
 ## Materials in Early development
 


### PR DESCRIPTION
This PR adds a table for the social science lessons to the lessons page. It also moves the Social Science lessons above Geospatial in the list, as they are scheduled for release at an earlier date than the Geospatial lessons. 