### PR TITLE
retire discussion forum

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -45,8 +45,6 @@
     url: "/involved-instructor/"
   - title: "Newsletter"
     url: "/newsletter/"
-  - title: "Discussion Forum"
-    url: "http://discuss.datacarpentry.org"
   - title: "Help Develop Lessons"
     url: "/involved-lessons/"
   - title: "Jobs"


### PR DESCRIPTION
Remove link to discussion form from navigation menu.

There has been no activity on this forum for about a year now. We are not actively maintaining it, monitoring it, or attempting to draw new participants to it. 