### PR TITLE
Add tags to various instructor-related blog posts

### DIFF
--- a/_posts/2016-03-18-instructor-training-africa.md
+++ b/_posts/2016-03-18-instructor-training-africa.md
@@ -9,7 +9,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Africa", "Instructor Development", "Workshops"]
 authors: ["Anelda van der Walt"]
 redirect_from: /blog/instructor-training-africa/
 ---

--- a/_posts/2016-05-17-r-instructor-training.md
+++ b/_posts/2016-05-17-r-instructor-training.md
@@ -9,7 +9,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Instructor Development", "Workshops"]
 authors: ["Greg Wilson"]
 redirect_from: /blog/r-instructor-training/
 ---

--- a/_posts/2016-05-19-instructor-metrics.md
+++ b/_posts/2016-05-19-instructor-metrics.md
@@ -9,7 +9,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Instructor Development"]
 authors: ["Erin Becker"]
 ---
 

--- a/_posts/2016-07-25-reopening-instructor-training.md
+++ b/_posts/2016-07-25-reopening-instructor-training.md
@@ -9,7 +9,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Instructor Development"]
 authors: ["Greg Wilson"]
 redirect_from: /blog/reopening-instructor-training/
 ---

--- a/_posts/2016-11-16-open-instructor-training.md
+++ b/_posts/2016-11-16-open-instructor-training.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Instructor Development"]
 authors: ["Erin Becker", "Greg Wilson"]
 redirect_from: /blog/open-instructor-training/
 ---

--- a/_posts/2016-12-08-csv-conf.md
+++ b/_posts/2016-12-08-csv-conf.md
@@ -9,7 +9,7 @@ categories:
   - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Instructor Development", "North America"]
 authors: ["Greg Wilson"]
 redirect_from: /blog/csv-conf/
 ---

--- a/_posts/2017-01-31-moving-forward.md
+++ b/_posts/2017-01-31-moving-forward.md
@@ -9,7 +9,7 @@ Categories:
   - blog  
 comments: true  
 show_meta: true    
-tags: [""]
+tags: ["Governance", "Instructor Development"]
 authors: ["Erin Becker"]    
 redirect_from: /blog/moving-forward/
 ---  

--- a/_posts/2017-04-24-UPRtraining.md
+++ b/_posts/2017-04-24-UPRtraining.md
@@ -9,7 +9,7 @@ categories:
   - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Instructor Development", "Latin America", "Workshops"]
 authors: [Rayna Harris, Sue McClatchy, Tracy Teal]
 redirect_from: /blog/UPRtraining/
 ---

--- a/_posts/2017-05-31-trainers-apply.md
+++ b/_posts/2017-05-31-trainers-apply.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Instructor Development", "Trainers"]
 authors: ["Erin Becker"]
 redirect_from: /blog/trainers-apply/
 ---

--- a/_posts/2017-07-11-instructor-training-bonanza.md
+++ b/_posts/2017-07-11-instructor-training-bonanza.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Events", "Instructor Development"]
 authors: [Erin Becker]
 redirect_from: /blog/instructor-training-bonanza/
 ---

--- a/_posts/2017-07-27-inst-bug-bbq.md
+++ b/_posts/2017-07-27-inst-bug-bbq.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Bug BBQ", "Events", "Instructor Development"]
 authors: ["Belinda Weaver", "Erin Becker"]
 redirect_from: /blog/inst-bug-bbq/
 ---

--- a/_posts/2018-02-27-checkout-update.md
+++ b/_posts/2018-02-27-checkout-update.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: [""]
+tags: ["Instructor Development"]
 authors: ["Erin Becker"]
 redirect_from: /blog/checkout-update/
 ---


### PR DESCRIPTION
Related to #499.

I went through several posts that had to do with instructor training and suggested keywords for them. I tried to base this on the tags from the [main Carpentries blog](https://carpentries.org/posts-by-tags/).