### PR TITLE
direct "other curriculum" section to incubator

### DIFF
--- a/pages/lessons.md
+++ b/pages/lessons.md
@@ -415,7 +415,9 @@ Development of a Data Carpentry lesson immediately aimed at astronomy, but which
 
 ### <a id="other-curriculum"></a>Other curriculum
 
-If you are interested in developing other lessons or getting updates on other topics, see the [lessons ideas github repository](https://github.com/datacarpentry/lesson-ideas) for topics under consideration or discussion, or to propose new ideas.
+If you are interested in developing other lessons, please visit [The Carpentries Incubator](https://github.com/carpentries-incubator/proposals/blob/master/README.md).
+
+
 
 ## Semester materials
 


### PR DESCRIPTION
This currently links to the [lesson ideas repo](https://github.com/carpentries-incubator/lesson-ideas) which is archived and refers to the incubator.  This fix updates the text on the DC lesson page accordingly.