### PR TITLE
correct link to reference page

### DIFF
--- a/pages/lessons.md
+++ b/pages/lessons.md
@@ -269,7 +269,7 @@ Please note that workshop materials for working with Social Science data in Pyth
     <td>Data Cleaning with OpenRefine for Social Scientists</td>
     <td><a href="http://www.datacarpentry.org/openrefine-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="{{site.dc_github_repo_url}}/openrefine-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.dc_github_site_url}}/openrefine-socialsci/reference" target="_blank" class="icon-eye" title="Reference for OpenRefine social science lesson"></a></td>
+    <td><a href="{{site.dc_github_site_url}}/openrefine-socialsci/reference/" target="_blank" class="icon-eye" title="Reference for OpenRefine social science lesson"></a></td>
     <td><a href="{{site.dc_github_site_url}}/openrefine-socialsci/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for OpenRefine social science lesson"></a></td>
     <td>Geoff LaFlair, Isaac Williams, Sarah Brown</td>
 </tr>

--- a/pages/lessons.md
+++ b/pages/lessons.md
@@ -269,7 +269,7 @@ Please note that workshop materials for working with Social Science data in Pyth
     <td>Data Cleaning with OpenRefine for Social Scientists</td>
     <td><a href="http://www.datacarpentry.org/openrefine-socialsci/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="{{site.dc_github_repo_url}}/openrefine-socialsci/" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.dc_github_site_url}}/openrefine-socialsci/reference.html" target="_blank" class="icon-eye" title="Reference for OpenRefine social science lesson"></a></td>
+    <td><a href="{{site.dc_github_site_url}}/openrefine-socialsci/reference" target="_blank" class="icon-eye" title="Reference for OpenRefine social science lesson"></a></td>
     <td><a href="{{site.dc_github_site_url}}/openrefine-socialsci/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for OpenRefine social science lesson"></a></td>
     <td>Geoff LaFlair, Isaac Williams, Sarah Brown</td>
 </tr>


### PR DESCRIPTION
Styles renders the reference page at /reference/ on (at least many) lessons, if it shouldn't @zkamvar or @fmichonneau should advise where to make the change instead. 

'reference.html' -> 'reference/' needs to be made throughout the whole page.

Discovered via issue submitted to [socialsci-openrefine/#75](https://github.com/datacarpentry/openrefine-socialsci/issues/75)