### PR TITLE
Add language stating blog inactivity

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -5,3 +5,5 @@ format: blog-index
 noindex: true
 ---
 {% include pagination.html %}
+
+<h1> Note: This blog is inactive. For updates from and about the Data Carpentry community, please visit <a href="https://carpentries.org/blog">The Carpentries blog</a></h1>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -4,6 +4,9 @@ format: blog-index
 # Don't index these pages dear Google.
 noindex: true
 ---
-{% include pagination.html %}
 
 <h1> Note: This blog is inactive. For updates from and about the Data Carpentry community, please visit <a href="https://carpentries.org/blog">The Carpentries blog</a></h1>
+
+
+{% include pagination.html %}
+

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -81,7 +81,7 @@ format: blog-index
 <div class="row t60">
   <div class="medium-20">
 
-          
+
     <h2>{{ site.data.language.upcoming_workshops }}</h2>
 
     {% assign workshop_list = site.data.dc_upcoming_workshops %}
@@ -98,8 +98,8 @@ format: blog-index
   <div class="medium-20">
     <h2>{{ site.data.language.more_articles }}</h2>
     <p>
-      In addition to the posts below,
-      find out what's happening in our community through
+      The Data Carpentry blog is no longer updated regularly.
+      You can find more information about what's happening in our community through
       <a href="https://carpentries.org/blog">The Carpentries blog</a>,
       a great resource that collates posts from Data Carpentry,
       Library Carpentry, and Software Carpentry, and


### PR DESCRIPTION
This Pull Request is to add language that indicates the Data Carpentry blog is no longer updates and directs viewers to the main Carpentries blog