### PR TITLE
anchor link white space

### DIFF
--- a/_sass/_09_elements.scss
+++ b/_sass/_09_elements.scss
@@ -139,3 +139,15 @@ dd.accordion-navigation span:before { content: "\F107" }
 dd.accordion-navigation.active span:before { content: "\F105" }
 dd.accordion-navigation.active span:before { content: "\F105" }
 
+*:target:not([id^='fn:']):not([id^='fnref:']) {
+    &::before {
+        content: " ";
+        width: 0;
+        height: 0;
+
+        display: block;
+        padding-top: 50px;
+        margin-top: -50px;
+    }
+}
+


### PR DESCRIPTION
Fixes css to add white space around anchor links so they don't get hidden by navbar.
See
carpentries/carpentries.org#1405