### PR TITLE
Change DC Twitter link to Mastodon link

### DIFF
--- a/_data/socialmedia.yml
+++ b/_data/socialmedia.yml
@@ -1,44 +1,9 @@
-#- name: YouTube
-#  url: http://www.youtube.com/PhlowMedia
-#  class: icon-youtube
-#  title: "Videos, Video-Anleitungen und Filme von Phlow auf YouTube"
-
-- name: Twitter
-  url: http://twitter.com/datacarpentry
-  class: icon-twitter
-  title: "Data Carpentry on Twitter"
-
-#- name: Facebook
-#  url: http://www.facebook.com/phlow.media
-#  class: icon-facebook
-#  title: "Lass uns Freunde sein!"
-
-#- name: Soundcloud
-#  url: http://soundcloud.com/phlow
-#  class: icon-soundcloud
-#  title: "Sounds und Downloads und mehr"
+- name: Mastodon
+  url: https://hachyderm.io/@thecarpentries
+  class: fab fa-mastodon
+  title: "The Carpentries on Mastodon"
 
 - name: GitHub
   url: http://github.com/datacarpentry
   class: icon-github
   title: "Data Carpentry on GitHub"
-
-#- name: Instagram
-#  url: http://instagram.com/phlowmedia
-#  class: icon-instagram
-#  title: "Bilder und Impressionen mit und ohne Filter..."
-
-#- name: Pinterest
-#  url: http://www.pinterest.com/phlowmedia/
-#  class: icon-pinterest
-#  title: "Bilder, Fotos, Illustrationen, Grafiken sammeln..."
-
-#- name: Mixcloud
-#  url: http://www.mixcloud.com/phlow/
-#  class: icon-cloud
-#  title: "Mixe, was sonst?"
-
-# - name: Xing
-#   url: https://www.xing.com/profile/Moritzmo_Sauer
-#   class: icon-xing
-#   title: Xing Profil

--- a/_data/socialmedia.yml
+++ b/_data/socialmedia.yml
@@ -5,5 +5,5 @@
 
 - name: GitHub
   url: http://github.com/datacarpentry
-  class: icon-github
+  class: fab fa-github
   title: "Data Carpentry on GitHub"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,6 +29,9 @@
         <noscript><p><img src="https://carpentries.matomo.cloud/matomo.php?idsite=8&amp;rec=1" style="border:0;" alt="" /></p></noscript>
         <!-- End Matomo Code -->
 
+  <!-- Adding Font Awesome -->
+  <script src="https://kit.fontawesome.com/3a6fac633d.js" crossorigin="anonymous"></script>
+  
   <noscript>
     <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic%7cVolkhov' rel='stylesheet' type='text/css'>
   </noscript>

--- a/_sass/_07_layout.scss
+++ b/_sass/_07_layout.scss
@@ -297,8 +297,9 @@ body.video cite { color: #fff; }
     }
     #subfooter .social-icons li a {
         font-size: rem-calc(23);
+        padding: rem-calc(7); // font-size + 2*padding = width
         display: block;
-        width: 36px;
+        width: rem-calc(37);
         border-radius: 50%;
         color: $subfooter-bg;
         background: $subfooter-color;

--- a/blog/index.html
+++ b/blog/index.html
@@ -10,10 +10,4 @@ header:
     <h2>Recent Blog Posts</h2>
     {% include list-posts.html entries='30' %}
   </div>
-<div class="medium-4 columns">
-    <a class="twitter-timeline"  href="https://twitter.com/datacarpentry" data-widget-id="631240261553623040">Tweets by @datacarpentry</a>
-          <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-    </a>
-    </p>
-</div>
 </div>


### PR DESCRIPTION
Removes the DC Twitter from the website, and replaces it with The Carpentries' unified Mastodon link.

I had to switch the social icons to FontAwesome to get the Mastodon icon, and tweak the CSS accordingly.

I also removed the Twitter sidebar from the blog page (it's broken anyway)