### PR TITLE
rm self org workshops from menu

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -89,8 +89,6 @@
     url: "/checkout/"
   - title: Workshop Checklists
     url: "/checklists/"
-  - title: Self-Organised Workshops
-    url: "/self-organized-workshops/"
   - title: Mentoring Opportunities
     url: "/mentoring/"
 


### PR DESCRIPTION
Removes "self organized workshops" from "For Instructors" menu in navbar.  Fixes #613