### PR TITLE
redirect Curriculum Advisors page to Carpentries website page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -72,7 +72,7 @@
   - title: "In Development"
     url: "/lessons/#materials-in-early-development"
   - title: "Curriculum Advisory Committeee"
-    url: "/curriculum-advisors/"
+    url: "https://carpentries.org/curriculum-advisors/"
 
 - title: Blog
   url: "/blog/"

--- a/pages/curriculum-advisors.md
+++ b/pages/curriculum-advisors.md
@@ -5,11 +5,7 @@ title: "Curriculum Advisors"
 header:
     image_fullwidth: "wood_plank.jpg"
 permalink: "/curriculum-advisors/"
+redirect_to:
+  - https://carpentries.org/curriculum-advisors/
 ---
 
-Curriculum Advisors are part of a team that provides the oversight, 
-vision, and leadership for a particular set of lessons. More information 
-about the role of the Curriculum Advisory Committee can be found in the
-[Carpentries Handbook](http://docs.carpentries.org/topic_folders/lesson_development/lesson_development_roles.html#curriculum-advisory-committee). 
-
-Data Carpentry Curriculum Advisors were announced in [this February 2022 blog post](https://carpentries.org/blog/2022/02/announcing-new-cacs/).  For current membership and contact information, refer to [The Carpentries Curriculum Advisors page](https://carpentries.org/curriculum-advisors/).


### PR DESCRIPTION
Fixes #611