### PR TITLE
Remove inactive Maintainers

### DIFF
--- a/pages/lessons.md
+++ b/pages/lessons.md
@@ -102,7 +102,7 @@ The Ecology [Curriculum Advisory Committee](https://carpentries.org/curriculum-a
     <td><a href="{{site.dc_github_repo_url}}/spreadsheet-ecology-lesson/" target="_blank" class="icon-github" title="Repository for Spreadsheet Ecology Lesson"></a></td>
 	<td><a href="{{site.dc_github_site_url}}/spreadsheet-ecology-lesson/reference.html" target="_blank" class="icon-eye" title="Reference for Spreadsheet Ecology Lesson"></a></td>
     <td><a href="{{site.dc_github_site_url}}/spreadsheet-ecology-lesson/instructor-notes.html" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Spreadsheet Ecology Lesson"></a></td>
-    <td>Monah Abou Alezz, Peter R. Hoyt</td>
+    <td>TBD</td>
   </tr>
   <tr>
     <td>Data Cleaning with OpenRefine for Ecologists</td>
@@ -126,7 +126,7 @@ The Ecology [Curriculum Advisory Committee](https://carpentries.org/curriculum-a
     <td><a href="{{site.dc_github_repo_url}}/R-ecology-lesson/" target="_blank" class="icon-github" title="Repository for R Ecology Lesson"></a></td>
 		<td><a href="{{site.dc_github_site_url}}/R-ecology-lesson/reference" target="_blank" class="icon-eye" title="Reference for R Ecology Lesson"></a></td>
     <td><a href="{{site.dc_github_site_url}}/R-ecology-lesson/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for R Ecology Lesson"></a></td>
-    <td>James Azam, Jay Lee, Aswathi Surendran</td>
+    <td>James Azam, Jay Lee</td>
   </tr>
   <tr>
     <td>Data Analysis and Visualization in Python for Ecologists</td>
@@ -134,7 +134,7 @@ The Ecology [Curriculum Advisory Committee](https://carpentries.org/curriculum-a
     <td><a href="{{site.dc_github_repo_url}}/python-ecology-lesson/" target="_blank" class="icon-github" title="Repository for Python Ecology Lesson"></a></td>
 	<td><a href="{{site.dc_github_site_url}}/python-ecology-lesson/reference.html" target="_blank" class="icon-eye" title="Reference for Python Ecology Lesson"></a></td>
     <td><a href="{{site.dc_github_site_url}}/python-ecology-lesson/instructor-notes.html" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Python Ecology Lesson"></a></td>
-    <td>Alex Pakalniskis, Sarah Pohl, Benjamin Tovar</td>
+    <td>Sarah Pohl, Benjamin Tovar</td>
   </tr>
 </table>
 
@@ -203,7 +203,7 @@ Anuj Guruacharya, Travis Wrightsman</td>
     <td><a href="{{site.dc_github_repo_url}}/organization-genomics/" target="_blank" class="icon-github" title="Repository for Project organization in genomics"></a></td>
 	<td><a href="{{site.dc_github_site_url}}/organization-genomics/reference.html" target="_blank" class="icon-eye" title="Reference for Project organization in genomics"></a></td>
     <td><a href="{{site.dc_github_site_url}}/organization-genomics/instructor-notes.html" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Project organization in genomics"></a></td>
-    <td>Peter Hoyt, Heidi Steiner, Jake Szamosi</td>
+    <td>Heidi Steiner, Jake Szamosi</td>
 </tr>
   <tr>
     <td>Introduction to the Command Line for Genomics</td>
@@ -219,7 +219,7 @@ Anuj Guruacharya, Travis Wrightsman</td>
    <td><a href="{{site.dc_github_repo_url}}/wrangling-genomics/" target="_blank" class="icon-github" title="Repository for Data wrangling genomics lesson"></a></td>
    <td><a href="{{site.dc_github_site_url}}/wrangling-genomics/reference.html" target="_blank" class="icon-eye" title="Reference for data wrangling genomics lesson"></a></td>
     <td><a href="{{site.dc_github_site_url}}/wrangling-genomics/instructor-notes.html" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for data wrangling genomics lesson"></a></td>
-    <td>Josh Herr, Rhondene Wint </td>
+    <td>Josh Herr</td>
   </tr>
   <tr>
     <td>Introduction to Cloud Computing for Genomics</td>
@@ -227,7 +227,7 @@ Anuj Guruacharya, Travis Wrightsman</td>
    <td><a href="{{site.dc_github_repo_url}}/cloud-genomics/" target="_blank" class="icon-github" title="Repository for introduction to cloud computing for genomics lesson"></a></td>
    <td><a href="{{site.dc_github_site_url}}/cloud-genomics/reference.html" target="_blank" class="icon-eye" title="Reference for cloud computing for genomics lesson"></a></td>
     <td><a href="{{site.dc_github_site_url}}/cloud-genomics/instructor-notes.html" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for cloud computing for genomics lesson"></a></td>
-    <td>Anuj Guruacharya, Wendy Wong</td>
+    <td>TBD</td>
   </tr>
 </table>
 
@@ -249,7 +249,7 @@ Anuj Guruacharya, Travis Wrightsman</td>
     <td><a href="{{site.dc_github_repo_url}}/genomics-r-intro/" target="_blank" class="icon-github" title="Repository for data analysis of genomics data in R"></a></td>
 	<td><a href="{{site.dc_github_site_url}}/genomics-r-intro/reference.html" target="_blank" class="icon-eye" title="Reference for R genomics lesson"></a></td>
     <td><a href="{{site.dc_github_site_url}}/genomics-r-intro/instructor-notes.html" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for R genomics lesson"></a></td>
-    <td>Krzysztof Poterlowicz, Yuka Takemon, Jason Williams, Naupaka Zimmerman</td>
+    <td>Yuka Takemon, Jason Williams, Naupaka Zimmerman</td>
   </tr>
 </table>
 
@@ -290,7 +290,7 @@ Instructor. Instructors who have completed onboarding will be given priority sta
         <td><a href="{{site.dc_github_repo_url}}/organization-geospatial/" target="_blank" class="icon-github" title="Repository for Introduction to Geospatial Concepts"></a></td>
         <td><a href="{{site.dc_github_site_url}}/organization-geospatial/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Geospatial Concepts"></a></td>
         <td>&nbsp;</td>
-        <td>Marissa Block, Rohit Goswami, Girmaye Misgna, Aditya Ranganath, Tyson Swetnam</td>
+        <td>Marissa Block, Rohit Goswami, Girmaye Misgna, Aditya Ranganath</td>
     </tr>
     <tr>
         <td>Introduction to R for Geospatial Data</td>
@@ -396,7 +396,7 @@ Please note that workshop materials for working with Social Science data in Pyth
     <td><a href="{{site.dc_github_repo_url}}/openrefine-socialsci/" target="_blank" class="icon-github" title="Repository for Data Cleaning with OpenRefine for Social Scientists"></a></td>
     <td><a href="{{site.dc_github_site_url}}/openrefine-socialsci/reference.html" target="_blank" class="icon-eye" title="Reference for Data Cleaning with OpenRefine for Social Scientists"></a></td>
     <td><a href="{{site.dc_github_site_url}}/openrefine-socialsci/instructor-notes.html" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Data Cleaning with OpenRefine for Social Scientists"></a></td>
-    <td>Ben Companjen, Emilia Gan</td>
+    <td>Ben Companjen</td>
 </tr>
 <tr>
     <td>Data Analysis and Visualization with R for Social Scientists</td>
@@ -426,7 +426,7 @@ Please note that workshop materials for working with Social Science data in Pyth
     <td><a href="{{site.dc_github_repo_url}}/python-socialsci/" target="_blank" class="icon-github" title="Repository for Python for Social Scientists"></a></td>
     <td><a href="{{site.dc_github_site_url}}/python-socialsci/reference.html" target="_blank" class="icon-eye" title="Reference for Python for Social Scientists"></a></td>
     <td><a href="{{site.dc_github_site_url}}/python-socialsci/instructor-notes.html" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Python for Social Scientists"></a></td>
-    <td>Annajiat Alim Rasel</td>
+    <td></td>
 </tr>
 <tr>
     <td>Data Management with SQL for Social Scientists *alpha*</td>


### PR DESCRIPTION
Remove Maintainers who did not respond to issues related to Workbench transition.

https://github.com/datacarpentry/cloud-genomics/issues/121
https://github.com/datacarpentry/genomics-r-intro/issues/204
https://github.com/datacarpentry/openrefine-socialsci/issues/140
https://github.com/datacarpentry/organization-genomics/issues/152
https://github.com/datacarpentry/organization-geospatial/issues/82
https://github.com/datacarpentry/python-ecology-lesson/issues/543
https://github.com/datacarpentry/python-socialsci/issues/187
https://github.com/datacarpentry/R-ecology-lesson/issues/841
https://github.com/datacarpentry/spreadsheet-ecology-lesson/issues/329
https://github.com/datacarpentry/wrangling-genomics/issues/240

Affected Maintainers can re-establish access by contacting [curriculum@carpentries.org](mailto:curriculum@carpentries.org) after re-cloning their lesson repo(s) on their local machine.