### PR TITLE
Remove mentoring

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -87,8 +87,6 @@
     url: "https://carpentries.github.io/instructor-training/checkout"
   - title: Workshop Checklists
     url: "/checklists/"
-  - title: Mentoring Opportunities
-    url: "/mentoring/"
 
 - title: "Sponsors"
   url: "https://carpentries.org/supporters/"

--- a/pages/mentoring.md
+++ b/pages/mentoring.md
@@ -6,6 +6,6 @@ header:
    image_fullwidth: "wood_plank.jpg"
 permalink: "/mentoring/"
 redirect_to:
-  - https://docs.carpentries.org/topic_folders/instructor_development/mentoring_groups.html
+  - https://docs.carpentries.org/topic_folders/instructor_development/instructor_development_committee.html
 ---
 


### PR DESCRIPTION
Following [this change to the handbook](https://github.com/carpentries/docs.carpentries.org/pull/949) removing mentoring groups, this removes references to mentoring on the DC site. 