### PR TITLE
Update matomo tracking code to Carpentries self-hosted

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,19 +19,19 @@
           _paq.push(['trackPageView']);
           _paq.push(['enableLinkTracking']);
           (function() {
-              var u="https://carpentries.matomo.cloud/";
-              _paq.push(['setTrackerUrl', u+'matomo.php']);
-              _paq.push(['setSiteId', '8']);
-              var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-              g.async=true; g.src='//cdn.matomo.cloud/carpentries.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+            var u="https://matomo.carpentries.org/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '8']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
           })();
         </script>
-        <noscript><p><img src="https://carpentries.matomo.cloud/matomo.php?idsite=8&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+        <noscript><p><img src="https://matomo.carpentries.org/matomo.php?idsite=8&amp;rec=1" style="border:0;" alt="" /></p></noscript>
         <!-- End Matomo Code -->
 
   <!-- Adding Font Awesome -->
   <script src="https://kit.fontawesome.com/3a6fac633d.js" crossorigin="anonymous"></script>
-  
+
   <noscript>
     <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic%7cVolkhov' rel='stylesheet' type='text/css'>
   </noscript>


### PR DESCRIPTION
We have recently brought our Matomo hosting within our own infrastructure to enable us to track more sites. This PR updates the tracking code to our self-hosted Matomo instance.